### PR TITLE
feat: i18n(ES) Added react admin 4.14.0 keys

### DIFF
--- a/packages/ra-language-spanish/package.json
+++ b/packages/ra-language-spanish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blackbox-vision/ra-language-spanish",
-  "version": "4.11.2",
+  "version": "4.11.3",
   "description": "Spanish messages for react-admin, the frontend framework for building admin applications on top of REST/GraphQL services",
   "author": "JonatanSalas <jonatan.salas@blackbox-vision.tech>",
   "homepage": "https://github.com/BlackBoxVision/react-admin-extensions#readme",

--- a/packages/ra-language-spanish/src/index.ts
+++ b/packages/ra-language-spanish/src/index.ts
@@ -40,6 +40,7 @@ const spanishMessages: Required<TranslationMessages> = {
       open:"Abrir",
       toggle_theme: "Alternar tema",
       select_columns: "Columnas",
+      update_application: 'Recargar Aplicación',
     },
     boolean: {
       true: "Sí",
@@ -156,6 +157,7 @@ const spanishMessages: Required<TranslationMessages> = {
       canceled: "Acción cancelada",
       logged_out: "Su sesión ha finalizado, vuelva a conectarse.",
       not_authorized: "No tiene autorización para acceder a este recurso.",
+      application_update_available: 'Una nueva versión está disponible.',
     },
     validation: {
       required: "Requerido",


### PR DESCRIPTION
Added the translation keys for the new [CheckForApplicationUpdate](https://marmelab.com/react-admin/CheckForApplicationUpdate.html#internationalization) component
